### PR TITLE
Travis CI Configuration and README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+env:
+  global:
+    - setup=stable
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+    - php: 7.1
+      env: setup=lowest
+    - php: 7.2
+    - php: 7.2
+      env: setup=lowest
+    - php: 7.3
+    - php: 7.3
+      env: setup=lowest
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
+
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "distinctm/laravel-data-sync",
-    "description": "Laravel utility to keep records synced between enviroments through source control",
+    "description": "Laravel utility to keep records synced between environments through source control",
     "license": "MIT",
     "authors": [
         {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 <p align="center">
 <a href="https://packagist.org/packages/distinctm/laravel-data-sync" target="_blank"><img src="https://poser.pugx.org/distinctm/laravel-data-sync/d/total.svg" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/distinctm/laravel-data-sync" target="_blank"><img src="https://poser.pugx.org/distinctm/laravel-data-sync/v/stable.svg" alt="Latest Stable Version"></a>
+<a href="https://travis-ci.com/distinctm/laravel-data-sync"><img src="https://www.travis-ci.com/distinctm/laravel-data-sync.svg?branch=master" alt="Travis CI Build Status: Master"></a>
 </p>
 
 # Laravel Data Sync


### PR DESCRIPTION
This commit adds travis-ci.com configuration and the related build status badge to the README header.

@distinctm I guess only thing after the merge is to follow the link from the readme and create the Travis CI side of things. I haven't done this before for others, just for some projects I own. Open source projects are ["always free"](https://travis-ci.com/plans).

One thing to consider is should we keep PHP 7.1 in the matrix, as [it is currently in the orange zone](https://www.php.net/supported-versions.php).
I included it because the reality is that there's still a lot of servers running that version (and even older versions).